### PR TITLE
Move global arrays to function scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,6 @@ const fs = Promise.promisifyAll(require('fs'));
 const Liquid = require("liquid-node");
 const engine = new Liquid.Engine;
 
-var errors = [];
-var allchecks = [];
-
 const replaceProblemWithSpace = (chunk, err) => {
   const problemReg = /at (.*) /;
   const replacer = err.message.match(problemReg)[1];
@@ -18,7 +15,7 @@ const replaceProblemWithSpace = (chunk, err) => {
   return replacedstring.join('\n');
 };
 
-const parseChunk = (chunk) => {
+const parseChunk = (chunk, errors) => {
   return engine
     .parse(chunk)
     .catch((err) => {
@@ -36,30 +33,34 @@ const parseChunk = (chunk) => {
 
 const linter = {
   lintFile: (filepath, callback) => {
-    errors = [];
+    const errors = [];
+    const allchecks = [];
     const testString = fs.readFileSync(filepath).toString();
-    allchecks.push(parseChunk(testString));
+    allchecks.push(parseChunk(testString, errors));
     Promise.all(allchecks)
       .then(() => callback(errors.reverse()));
   },
   lintFilePromise: (filepath) => {
-    errors = [];
+    const errors = [];
+    const allchecks = [];
     return fs.readFileAsync(filepath)
       .then((buffer) => {
-        allchecks.push(parseChunk(buffer.toString()));
+        allchecks.push(parseChunk(buffer.toString(), errors));
         return Promise.all(allchecks)
           .then(() => errors.reverse());
       });
   },
   lintString: (string, callback) => {
-    errors = [];
-    allchecks.push(parseChunk(string));
+    const errors = [];
+    const allchecks = [];
+    allchecks.push(parseChunk(string, errors));
     Promise.all(allchecks)
       .then(() => callback(errors.reverse()));
   },
   lintStringPromise: (string) => {
-    errors = [];
-    allchecks.push(parseChunk(string));
+    const errors = [];
+    const allchecks = [];
+    allchecks.push(parseChunk(string, errors));
     return Promise.all(allchecks)
       .then(() => errors.reverse());
   },

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const parseChunk = (chunk, errors) => {
         errors.push(err);
       }
       chunk = replaceProblemWithSpace(chunk, err);
-      return parseChunk(chunk);
+      return parseChunk(chunk, errors);
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liquid-linter",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A liquid template language linter",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As suggested by [@ddprrt](https://github.com/ddprrt), linting errors are shown file by file, if errors & allchecks arrays are moved to function scope.
parseChunk gets enhanced by the errors array parameter, possible linting errors therefore get pushed by reference.
